### PR TITLE
fix npm script usage

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -2,4 +2,5 @@ import { $ } from "bun";
 
 if (process.env.NODE_ENV === "development") {
 	await Promise.all([$`bunx lefthook install`]);
+	console.log("To get started developing: edit src/main.ts and `bun start`");
 }


### PR DESCRIPTION
"postinstall" だと、 `bun create ndxbn/bun` でつくったものを `npm publish` して（name: foo）、それを `npm install foo` した側（name: using-foo-project）でも ndxbn/bun の postinstall が実行されてしまいエラーになるので。

`bun create ndxbn/bun` とかってした場合に、

> # To get started, run:
> bun dev

と表示されるのって、 開発作業を開始するために必要な前処理を `bun dev` に書け、という意図だと思うんですよね。

で、とりあえず実行してみるっていうのが `bun start` 何だと思う。