### PR TITLE
Revert "disable docker build push as default"

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -1,11 +1,9 @@
 name: Create and publish a Docker image
 
 on:
-  { }
-# comment in to enable this Actions
-#  push:
-#    branches:
-#      - main
+  push:
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Reverts ndxbn/bun#37

ref https://github.com/ndxbn/ndxbn/issues/2441

Orgs での internal/private なリポジトリでは、ちゃんと internal/private になってたので、デフォルトで `docker build` して良さそう。